### PR TITLE
fix: core when co_await move assigned awaiters

### DIFF
--- a/.github/workflows/centos-stream8.yml
+++ b/.github/workflows/centos-stream8.yml
@@ -1,7 +1,4 @@
 on:
-  push:
-    branches:
-    - master
   pull_request:
     branches:
     - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-    - master
     - 'dev*'
   pull_request:
     branches:

--- a/include/coke/fileio.h
+++ b/include/coke/fileio.h
@@ -18,15 +18,10 @@ struct FileResult {
     long nbytes;  // the number of bytes read or written
 };
 
-class FileAwaiter : public AwaiterBase {
+class FileAwaiter : public BasicAwaiter<FileResult> {
 public:
-    template<typename T>
-    explicit FileAwaiter(T *task);
-
-    FileResult await_resume() { return result; }
-
-private:
-    FileResult result;
+    template<typename Task>
+    explicit FileAwaiter(Task *task);
 };
 
 FileAwaiter pread(int fd, void *buf, size_t count, off_t offset);

--- a/include/coke/latch.h
+++ b/include/coke/latch.h
@@ -9,10 +9,9 @@
 
 namespace coke {
 
-class LatchAwaiter : public AwaiterBase {
+class LatchAwaiter : public BasicAwaiter<void> {
 public:
     explicit LatchAwaiter(SubTask *task);
-    void await_resume() { }
 };
 
 class Latch {

--- a/include/coke/sleep.h
+++ b/include/coke/sleep.h
@@ -7,16 +7,10 @@
 
 namespace coke {
 
-class SleepAwaiter : public AwaiterBase {
+class SleepAwaiter : public BasicAwaiter<int> {
 public:
-    SleepAwaiter() : state(0) { }
+    SleepAwaiter();
     SleepAwaiter(long sec, long nsec);
-
-    // may return STATE_SUCCESS or STATE_ABORTED
-    int await_resume() { return state; }
-
-private:
-    int state;
 };
 
 inline SleepAwaiter sleep(long sec, long nsec) {

--- a/src/fileio.cpp
+++ b/src/fileio.cpp
@@ -4,13 +4,15 @@
 
 namespace coke {
 
-template<typename T>
-FileAwaiter::FileAwaiter(T *task) {
-    task->set_callback([this] (T *t) {
-        this->result.state = t->get_state();
-        this->result.error = t->get_error();
-        this->result.nbytes = t->get_retval();
-        this->done();
+template<typename Task>
+FileAwaiter::FileAwaiter(Task *task) {
+    task->set_callback([info = this->get_info()] (Task *t) {
+        auto *awaiter = info->get_awaiter<FileAwaiter>();
+        awaiter->emplace_result(FileResult{
+            t->get_state(), t->get_error(), t->get_retval()
+        });
+
+        awaiter->done();
     });
 
     set_task(task);

--- a/src/latch.cpp
+++ b/src/latch.cpp
@@ -7,7 +7,13 @@ namespace coke {
 
 LatchAwaiter::LatchAwaiter(SubTask *task) {
     WFCounterTask *counter = static_cast<WFCounterTask *>(task);
-    counter->set_callback([this](WFCounterTask *) { this->done(); });
+    auto *info = this->get_info();
+
+    counter->set_callback([info](WFCounterTask *) {
+        auto *awaiter = info->get_awaiter<LatchAwaiter>();
+        awaiter->done();
+    });
+
     set_task(task);
 }
 

--- a/src/sleep.cpp
+++ b/src/sleep.cpp
@@ -4,10 +4,15 @@
 
 namespace coke {
 
+SleepAwaiter::SleepAwaiter() {
+    emplace_result(0);
+}
+
 SleepAwaiter::SleepAwaiter(long sec, long nsec) {
-    auto cb = [this](WFTimerTask *t) {
-        this->state = t->get_state();
-        this->done();
+    auto cb = [info = this->get_info()](WFTimerTask *task) {
+        auto *awaiter = info->get_awaiter<SleepAwaiter>();
+        awaiter->emplace_result(task->get_state());
+        awaiter->done();
     };
 
     set_task(WFTaskFactory::create_timer_task(sec, nsec, cb));

--- a/test/test_wait.cpp
+++ b/test/test_wait.cpp
@@ -105,10 +105,17 @@ coke::Task<std::string> identity(std::string s) {
 }
 
 TEST(WAIT, wait_awaitable) {
-    std::string s;
+    std::string s("hello");
     std::string t = coke::sync_wait(identity(s));
     EXPECT_EQ(s, t);
 
+    coke::SleepAwaiter slp = coke::sleep(0, 100ULL * 1000 * 1000);
+    int ret = coke::sync_wait(std::move(slp));
+    EXPECT_EQ(ret, coke::STATE_SUCCESS);
+}
+
+TEST(WAIT, wait_two_awaitable) {
+    std::string s("hello");
     std::vector<std::string> ret = coke::sync_wait(
         identity(s), identity(s)
     );


### PR DESCRIPTION
In the previous implementation, the `this` pointer of the awaiter was captured into the callback function of workflow's task. When the awaiter was moved assigned to another object, the `this` captured into the callback function would be destroyed. Calling the callback function at this time would cause problems.

Added BasicAwaiter and AwaiterInfo as a bridge, reacquire the current awaiter in the callback function to avoid using destroyed objects.